### PR TITLE
remove https from deploy url

### DIFF
--- a/cicd_stage_3.md
+++ b/cicd_stage_3.md
@@ -40,7 +40,7 @@ cd ~/coding/cicd_demoapp
           username: $$MANTL_USERNAME
           password: $$MANTL_PASSWORD
         urls:
-          - https://$$MANTL_CONTROL/marathon/v2/apps/class/$$DOCKER_USERNAME/restart?force=true
+          - $$MANTL_CONTROL/marathon/v2/apps/class/$$DOCKER_USERNAME/restart?force=true
     ```
 
 2. As part of the security of drone, every chance to the _.drone.yml_ file requires the secrets file to be recreated.  Sense we've updated this file, we need to resecure our secrets.


### PR DESCRIPTION
This was the only issue I ran into in running through the lab... i had specified the full URL in my drone.yml as such

`MANTL_CONTROL: https://control.green.browndogtech.com`

which caused the following error 

`Error: Failed to execute the HTTP request. Post https://http://control.green.browndogtech.com/marathon/v2/apps/class/kecorbin/restart?force=true: dial tcp: lookup http on 10.101.128.102:53: server misbehaving
[info] build failed (exit code 1)`

Not sure which way you want to go on this... I think either merging this PR, or providing some comment [here](https://github.com/kecorbin/cicd_learning_lab/blame/master/environment_prep.md#L107) for clarity would be good.
